### PR TITLE
Add unit tests for MariaDB Store query method

### DIFF
--- a/src/store/src/Bridge/MariaDB/Store.php
+++ b/src/store/src/Bridge/MariaDB/Store.php
@@ -113,7 +113,7 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
                     SQL,
                 $this->vectorFieldName,
                 $this->tableName,
-                null !== $minScore ? 'WHERE VEC_DISTANCE_EUCLIDEAN(%1$s, VEC_FromText(:embedding)) >= :minScore' : '',
+                null !== $minScore ? \sprintf('WHERE VEC_DISTANCE_EUCLIDEAN(%1$s, VEC_FromText(:embedding)) >= :minScore', $this->vectorFieldName) : '',
                 $options['limit'] ?? 5,
             ),
         );

--- a/src/store/tests/Bridge/MariaDB/StoreTest.php
+++ b/src/store/tests/Bridge/MariaDB/StoreTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Bridge\MariaDB;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\Bridge\MariaDB\Store;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\Component\Uid\Uuid;
+
+#[CoversClass(Store::class)]
+final class StoreTest extends TestCase
+{
+    public function testQueryWithMinScore(): void
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $statement = $this->createMock(\PDOStatement::class);
+
+        $store = new Store($pdo, 'embeddings_table', 'embedding_index', 'embedding');
+
+        // Expected SQL query with minScore
+        $expectedQuery = <<<'SQL'
+            SELECT id, VEC_ToText(embedding) embedding, metadata, VEC_DISTANCE_EUCLIDEAN(embedding, VEC_FromText(:embedding)) AS score
+            FROM embeddings_table
+            WHERE VEC_DISTANCE_EUCLIDEAN(embedding, VEC_FromText(:embedding)) >= :minScore
+            ORDER BY score ASC
+            LIMIT 5
+            SQL;
+
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->with($expectedQuery)
+            ->willReturn($statement);
+
+        $uuid = Uuid::v4();
+        $vectorData = [0.1, 0.2, 0.3];
+        $minScore = 0.8;
+
+        $statement->expects($this->once())
+            ->method('execute')
+            ->with([
+                'embedding' => json_encode($vectorData),
+                'minScore' => $minScore,
+            ]);
+
+        $statement->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_ASSOC)
+            ->willReturn([
+                [
+                    'id' => $uuid->toBinary(),
+                    'embedding' => json_encode($vectorData),
+                    'metadata' => json_encode(['title' => 'Test Document']),
+                    'score' => 0.85,
+                ],
+            ]);
+
+        $results = $store->query(new Vector($vectorData), [], $minScore);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(VectorDocument::class, $results[0]);
+        $this->assertSame(0.85, $results[0]->score);
+        $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
+    }
+
+    public function testQueryWithoutMinScore(): void
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $statement = $this->createMock(\PDOStatement::class);
+
+        $store = new Store($pdo, 'embeddings_table', 'embedding_index', 'embedding');
+
+        // Expected SQL query without minScore
+        $expectedQuery = <<<'SQL'
+            SELECT id, VEC_ToText(embedding) embedding, metadata, VEC_DISTANCE_EUCLIDEAN(embedding, VEC_FromText(:embedding)) AS score
+            FROM embeddings_table
+
+            ORDER BY score ASC
+            LIMIT 5
+            SQL;
+
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->with($expectedQuery)
+            ->willReturn($statement);
+
+        $uuid = Uuid::v4();
+        $vectorData = [0.1, 0.2, 0.3];
+
+        $statement->expects($this->once())
+            ->method('execute')
+            ->with(['embedding' => json_encode($vectorData)]);
+
+        $statement->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_ASSOC)
+            ->willReturn([
+                [
+                    'id' => $uuid->toBinary(),
+                    'embedding' => json_encode($vectorData),
+                    'metadata' => json_encode(['title' => 'Test Document']),
+                    'score' => 0.95,
+                ],
+            ]);
+
+        $results = $store->query(new Vector($vectorData));
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(VectorDocument::class, $results[0]);
+        $this->assertSame(0.95, $results[0]->score);
+    }
+
+    public function testQueryWithCustomLimit(): void
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $statement = $this->createMock(\PDOStatement::class);
+
+        $store = new Store($pdo, 'embeddings_table', 'embedding_index', 'embedding');
+
+        // Expected SQL query with custom limit
+        $expectedQuery = <<<'SQL'
+            SELECT id, VEC_ToText(embedding) embedding, metadata, VEC_DISTANCE_EUCLIDEAN(embedding, VEC_FromText(:embedding)) AS score
+            FROM embeddings_table
+
+            ORDER BY score ASC
+            LIMIT 10
+            SQL;
+
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->with($expectedQuery)
+            ->willReturn($statement);
+
+        $vectorData = [0.1, 0.2, 0.3];
+
+        $statement->expects($this->once())
+            ->method('execute')
+            ->with(['embedding' => json_encode($vectorData)]);
+
+        $statement->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_ASSOC)
+            ->willReturn([]);
+
+        $results = $store->query(new Vector($vectorData), ['limit' => 10]);
+
+        $this->assertCount(0, $results);
+    }
+}


### PR DESCRIPTION
## Summary
- Added comprehensive unit tests for the MariaDB Store query method
- Tests specifically validate the fix from PR #189 regarding sprintf placeholders in WHERE clause
- Ensures proper SQL query generation with and without minScore parameter

## Test plan
- [x] Test query with minScore parameter (validates the bug fix from PR #189)
- [x] Test query without minScore parameter
- [x] Test query with custom limit option
- [x] All tests mock PDO interactions to ensure isolated unit testing

🤖 Generated with [Claude Code](https://claude.ai/code)