### PR TITLE
Add DbalStore for automatic platform detection

### DIFF
--- a/examples/store/dbal-similarity-search.php
+++ b/examples/store/dbal-similarity-search.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Doctrine\DBAL\DriverManager;
+use Symfony\AI\Embedder\OpenAi\Embedder;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\Bridge\Dbal\Store;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+
+// Example using DBAL Store with automatic platform detection
+// This example demonstrates how the DBAL store automatically adapts
+// to different database platforms (MariaDB, PostgreSQL, etc.)
+
+// Configure your database connection
+// For MariaDB:
+$connectionParams = [
+    'driver' => 'pdo_mysql',
+    'host' => 'localhost',
+    'port' => 3306,
+    'dbname' => 'test',
+    'user' => 'root',
+    'password' => '',
+    'serverVersion' => '11.7.0-MariaDB',
+];
+
+// For PostgreSQL (uncomment to use):
+// $connectionParams = [
+//     'driver' => 'pdo_pgsql',
+//     'host' => 'localhost',
+//     'port' => 5432,
+//     'dbname' => 'test',
+//     'user' => 'postgres',
+//     'password' => 'postgres',
+// ];
+
+// Create DBAL connection
+$connection = DriverManager::getConnection($connectionParams);
+
+// Create the DBAL store - it will automatically detect the database platform
+$store = new Store($connection, 'embeddings');
+
+// Initialize the store (creates table and indexes)
+try {
+    $store->initialize(['dimensions' => 1536]); // OpenAI embeddings are 1536 dimensions
+    echo "Store initialized successfully!\n";
+} catch (\Exception $e) {
+    echo "Store initialization failed: ".$e->getMessage()."\n";
+}
+
+// Create embedder
+$embedder = new Embedder(HttpClient::create([
+    'auth_bearer' => $_ENV['OPENAI_API_KEY'] ?? throw new \Exception('Please set OPENAI_API_KEY'),
+]));
+
+// Sample documents
+$documents = [
+    'The capital of France is Paris.',
+    'Berlin is the capital of Germany.',
+    'London is the capital of the United Kingdom.',
+    'Rome is the capital of Italy.',
+    'Madrid is the capital of Spain.',
+];
+
+// Add documents to the store
+echo "\nAdding documents to the store...\n";
+foreach ($documents as $i => $content) {
+    $embedding = $embedder->embed($content);
+    
+    $document = new VectorDocument(
+        id: Uuid::v4(),
+        vector: new Vector($embedding->getData()),
+        metadata: new Metadata([
+            'content' => $content,
+            'index' => $i,
+        ]),
+    );
+    
+    $store->add($document);
+    echo "Added: $content\n";
+}
+
+// Query the store
+$query = 'What is the capital of France?';
+echo "\nQuerying: $query\n";
+
+$queryEmbedding = $embedder->embed($query);
+$results = $store->query(new Vector($queryEmbedding->getData()), ['limit' => 3]);
+
+echo "\nTop 3 results:\n";
+foreach ($results as $i => $result) {
+    $content = $result->metadata->get('content');
+    $score = round($result->score, 4);
+    echo sprintf("%d. %s (score: %s)\n", $i + 1, $content, $score);
+}
+
+// Demonstrate platform detection
+$platform = $connection->getDatabasePlatform();
+echo "\nDetected database platform: ".get_class($platform)."\n";

--- a/src/store/src/Bridge/Dbal/README.md
+++ b/src/store/src/Bridge/Dbal/README.md
@@ -1,0 +1,63 @@
+# DBAL Store
+
+The DBAL Store provides a database-agnostic vector store implementation that automatically adapts to different database platforms using Doctrine DBAL.
+
+## Features
+
+- **Automatic Platform Detection**: Automatically detects and adapts to the underlying database platform
+- **Lazy Connection**: Uses DBAL connection which supports lazy loading, solving issue #84
+- **Platform Support**:
+  - MariaDB >=11.7 (with native vector support)
+  - PostgreSQL (with pgvector extension)
+  - Easily extensible to support additional platforms
+
+## Installation
+
+```bash
+composer require doctrine/dbal
+```
+
+## Usage
+
+```php
+use Doctrine\DBAL\DriverManager;
+use Symfony\AI\Store\Bridge\Dbal\Store;
+
+// Create DBAL connection
+$connection = DriverManager::getConnection([
+    'driver' => 'pdo_mysql',
+    'host' => 'localhost',
+    'dbname' => 'mydb',
+    'user' => 'user',
+    'password' => 'pass',
+    'serverVersion' => '11.7.0-MariaDB',
+]);
+
+// Create store - platform is automatically detected
+$store = new Store($connection, 'embeddings_table');
+
+// Initialize the store (creates tables and indexes)
+$store->initialize(['dimensions' => 1536]);
+
+// Use the store...
+```
+
+## Platform-Specific Behavior
+
+### MariaDB
+- Uses native `VECTOR` type and `VEC_FromText`/`VEC_ToText` functions
+- Creates `VECTOR INDEX` for efficient similarity search
+- Uses `VEC_DISTANCE_EUCLIDEAN` for distance calculations
+
+### PostgreSQL
+- Requires pgvector extension
+- Uses `vector` type with array syntax
+- Creates ivfflat index with cosine similarity
+- Uses `<->` operator for distance calculations
+
+## Benefits Over Platform-Specific Stores
+
+1. **Single Implementation**: One store implementation handles multiple database platforms
+2. **Lazy Connection**: DBAL connections are lazy by default, solving the "heavy constructor" issue
+3. **Easy Migration**: Switch between supported databases without code changes
+4. **Future-Proof**: Easy to add support for new platforms as they add vector capabilities

--- a/src/store/src/Bridge/Dbal/Store.php
+++ b/src/store/src/Bridge/Dbal/Store.php
@@ -1,0 +1,324 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Dbal;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Platform\Vector\VectorInterface;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\InitializableStoreInterface;
+use Symfony\AI\Store\VectorStoreInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * A DBAL-based vector store that automatically handles platform-specific
+ * storage strategies for different database systems.
+ *
+ * Supported platforms:
+ * - MariaDB >=11.7 (with native vector support)
+ * - PostgreSQL (with pgvector extension)
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final readonly class Store implements VectorStoreInterface, InitializableStoreInterface
+{
+    /**
+     * @param string $tableName       The name of the table
+     * @param string $indexName       The name of the vector search index
+     * @param string $vectorFieldName The name of the field in the index that contains the vector
+     */
+    public function __construct(
+        private Connection $connection,
+        private string $tableName,
+        private string $indexName = 'embedding',
+        private string $vectorFieldName = 'embedding',
+    ) {
+        if (!class_exists(Connection::class)) {
+            throw new RuntimeException('For using DbalStore as retrieval vector store, the doctrine/dbal package needs to be installed.');
+        }
+    }
+
+    public function add(VectorDocument ...$documents): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof MariaDBPlatform) {
+            $this->addForMariaDB($documents);
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $this->addForPostgreSQL($documents);
+        } else {
+            throw new RuntimeException(\sprintf('Unsupported database platform: %s', $platform::class));
+        }
+    }
+
+    /**
+     * @param array{
+     *     limit?: positive-int,
+     * } $options
+     */
+    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof MariaDBPlatform) {
+            return $this->queryForMariaDB($vector, $options, $minScore);
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            return $this->queryForPostgreSQL($vector, $options, $minScore);
+        } else {
+            throw new RuntimeException(\sprintf('Unsupported database platform: %s', $platform::class));
+        }
+    }
+
+    /**
+     * @param array{
+     *     dimensions?: positive-int,
+     *     vector_size?: positive-int,
+     * } $options
+     */
+    public function initialize(array $options = []): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof MariaDBPlatform) {
+            $this->initializeForMariaDB($options);
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $this->initializeForPostgreSQL($options);
+        } else {
+            throw new RuntimeException(\sprintf('Unsupported database platform: %s', $platform::class));
+        }
+    }
+
+    /**
+     * @param VectorDocument[] $documents
+     *
+     * @throws DBALException
+     */
+    private function addForMariaDB(array $documents): void
+    {
+        $sql = \sprintf(
+            <<<'SQL'
+                INSERT INTO %1$s (id, metadata, %2$s)
+                VALUES (:id, :metadata, VEC_FromText(:vector))
+                ON DUPLICATE KEY UPDATE metadata = :metadata, %2$s = VEC_FromText(:vector)
+                SQL,
+            $this->tableName,
+            $this->vectorFieldName,
+        );
+
+        foreach ($documents as $document) {
+            $this->connection->executeStatement($sql, [
+                'id' => $document->id->toBinary(),
+                'metadata' => json_encode($document->metadata->getArrayCopy()),
+                'vector' => json_encode($document->vector->getData()),
+            ]);
+        }
+    }
+
+    /**
+     * @param VectorDocument[] $documents
+     *
+     * @throws DBALException
+     */
+    private function addForPostgreSQL(array $documents): void
+    {
+        $sql = \sprintf(
+            'INSERT INTO %1$s (id, metadata, %2$s)
+            VALUES (:id, :metadata, :vector)
+            ON CONFLICT (id) DO UPDATE SET metadata = EXCLUDED.metadata, %2$s = EXCLUDED.%2$s',
+            $this->tableName,
+            $this->vectorFieldName,
+        );
+
+        foreach ($documents as $document) {
+            $this->connection->executeStatement($sql, [
+                'id' => $document->id->toRfc4122(),
+                'metadata' => json_encode($document->metadata->getArrayCopy(), \JSON_THROW_ON_ERROR),
+                'vector' => $this->toPgvector($document->vector),
+            ]);
+        }
+    }
+
+    /**
+     * @param array{limit?: positive-int} $options
+     *
+     * @return VectorDocument[]
+     *
+     * @throws DBALException
+     */
+    private function queryForMariaDB(Vector $vector, array $options, ?float $minScore): array
+    {
+        $sql = \sprintf(
+            <<<'SQL'
+                SELECT id, VEC_ToText(%1$s) embedding, metadata, VEC_DISTANCE_EUCLIDEAN(%1$s, VEC_FromText(:embedding)) AS score
+                FROM %2$s
+                %3$s
+                ORDER BY score ASC
+                LIMIT %4$d
+                SQL,
+            $this->vectorFieldName,
+            $this->tableName,
+            null !== $minScore ? \sprintf('WHERE VEC_DISTANCE_EUCLIDEAN(%1$s, VEC_FromText(:embedding)) >= :minScore', $this->vectorFieldName) : '',
+            $options['limit'] ?? 5,
+        );
+
+        $params = ['embedding' => json_encode($vector->getData())];
+
+        if (null !== $minScore) {
+            $params['minScore'] = $minScore;
+        }
+
+        $documents = [];
+        $result = $this->connection->executeQuery($sql, $params);
+
+        foreach ($result->fetchAllAssociative() as $row) {
+            $documents[] = new VectorDocument(
+                id: Uuid::fromBinary($row['id']),
+                vector: new Vector(json_decode((string) $row['embedding'], true)),
+                metadata: new Metadata(json_decode($row['metadata'] ?? '{}', true)),
+                score: $row['score'],
+            );
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param array{limit?: positive-int} $options
+     *
+     * @return VectorDocument[]
+     *
+     * @throws DBALException
+     */
+    private function queryForPostgreSQL(Vector $vector, array $options, ?float $minScore): array
+    {
+        $sql = \sprintf(
+            'SELECT id, %s AS embedding, metadata, (%s <-> :embedding) AS score
+             FROM %s
+             %s
+             ORDER BY score ASC
+             LIMIT %d',
+            $this->vectorFieldName,
+            $this->vectorFieldName,
+            $this->tableName,
+            null !== $minScore ? "WHERE ({$this->vectorFieldName} <-> :embedding) >= :minScore" : '',
+            $options['limit'] ?? 5,
+        );
+
+        $params = [
+            'embedding' => $this->toPgvector($vector),
+        ];
+        if (null !== $minScore) {
+            $params['minScore'] = $minScore;
+        }
+
+        $documents = [];
+        $result = $this->connection->executeQuery($sql, $params);
+
+        foreach ($result->fetchAllAssociative() as $row) {
+            $documents[] = new VectorDocument(
+                id: Uuid::fromString($row['id']),
+                vector: new Vector($this->fromPgvector($row['embedding'])),
+                metadata: new Metadata(json_decode($row['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
+                score: $row['score'],
+            );
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param array{dimensions?: positive-int} $options
+     *
+     * @throws DBALException
+     */
+    private function initializeForMariaDB(array $options): void
+    {
+        if ([] !== $options && !\array_key_exists('dimensions', $options)) {
+            throw new InvalidArgumentException('The only supported option is "dimensions"');
+        }
+
+        $serverVersion = $this->connection->getServerVersion();
+
+        if (!str_contains((string) $serverVersion, 'MariaDB') || version_compare($serverVersion, '11.7.0') < 0) {
+            throw new InvalidArgumentException('You need MariaDB >=11.7 to use this feature');
+        }
+
+        $this->connection->executeStatement(
+            \sprintf(
+                <<<'SQL'
+                    CREATE TABLE IF NOT EXISTS %1$s (
+                        id BINARY(16) NOT NULL PRIMARY KEY,
+                        metadata JSON,
+                        %2$s VECTOR(%4$d) NOT NULL,
+                        VECTOR INDEX %3$s (%2$s)
+                    )
+                    SQL,
+                $this->tableName,
+                $this->vectorFieldName,
+                $this->indexName,
+                $options['dimensions'] ?? 1536,
+            ),
+        );
+    }
+
+    /**
+     * @param array{vector_size?: positive-int} $options
+     *
+     * @throws DBALException
+     */
+    private function initializeForPostgreSQL(array $options): void
+    {
+        $this->connection->executeStatement('CREATE EXTENSION IF NOT EXISTS vector');
+
+        $this->connection->executeStatement(
+            \sprintf(
+                'CREATE TABLE IF NOT EXISTS %s (
+                    id UUID PRIMARY KEY,
+                    metadata JSONB,
+                    %s vector(%d) NOT NULL
+                )',
+                $this->tableName,
+                $this->vectorFieldName,
+                $options['vector_size'] ?? 1536,
+            ),
+        );
+        $this->connection->executeStatement(
+            \sprintf(
+                'CREATE INDEX IF NOT EXISTS %s_%s_idx ON %s USING ivfflat (%s vector_cosine_ops)',
+                $this->tableName,
+                $this->vectorFieldName,
+                $this->tableName,
+                $this->vectorFieldName,
+            ),
+        );
+    }
+
+    private function toPgvector(VectorInterface $vector): string
+    {
+        return '['.implode(',', $vector->getData()).']';
+    }
+
+    /**
+     * @return float[]
+     */
+    private function fromPgvector(string $vector): array
+    {
+        return json_decode($vector, true, 512, \JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/store/tests/Bridge/Dbal/StoreTest.php
+++ b/src/store/tests/Bridge/Dbal/StoreTest.php
@@ -1,0 +1,309 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Bridge\Dbal;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\Bridge\Dbal\Store;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\Component\Uid\Uuid;
+
+#[CoversClass(Store::class)]
+final class StoreTest extends TestCase
+{
+    public function testConstructorThrowsWithoutDoctrineDbal(): void
+    {
+        if (class_exists(Connection::class)) {
+            $this->markTestSkipped('This test requires doctrine/dbal to not be installed');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('For using DbalStore as retrieval vector store, the doctrine/dbal package needs to be installed.');
+
+        $connection = $this->createMock(Connection::class);
+        new Store($connection, 'embeddings');
+    }
+
+    public function testAddWithUnsupportedPlatform(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform = $this->createMock(SQLitePlatform::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $store = new Store($connection, 'embeddings');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported database platform: '.SQLitePlatform::class);
+
+        $store->add(new VectorDocument(
+            id: Uuid::v4(),
+            vector: new Vector([0.1, 0.2, 0.3]),
+            metadata: new Metadata(['title' => 'Test']),
+        ));
+    }
+
+    public function testAddForMariaDB(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform = $this->createMock(MariaDBPlatform::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $uuid = Uuid::v4();
+        $vectorData = [0.1, 0.2, 0.3];
+        $metadata = ['title' => 'Test Document'];
+
+        $expectedSql = <<<'SQL'
+            INSERT INTO embeddings (id, metadata, embedding)
+            VALUES (:id, :metadata, VEC_FromText(:vector))
+            ON DUPLICATE KEY UPDATE metadata = :metadata, embedding = VEC_FromText(:vector)
+            SQL;
+
+        $connection->expects($this->once())
+            ->method('executeStatement')
+            ->with($expectedSql, [
+                'id' => $uuid->toBinary(),
+                'metadata' => json_encode($metadata),
+                'vector' => json_encode($vectorData),
+            ]);
+
+        $store = new Store($connection, 'embeddings');
+        $store->add(new VectorDocument(
+            id: $uuid,
+            vector: new Vector($vectorData),
+            metadata: new Metadata($metadata),
+        ));
+    }
+
+    public function testAddForPostgreSQL(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform = $this->createMock(PostgreSQLPlatform::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $uuid = Uuid::v4();
+        $vectorData = [0.1, 0.2, 0.3];
+        $metadata = ['title' => 'Test Document'];
+
+        $expectedSql = 'INSERT INTO embeddings (id, metadata, embedding)
+            VALUES (:id, :metadata, :vector)
+            ON CONFLICT (id) DO UPDATE SET metadata = EXCLUDED.metadata, embedding = EXCLUDED.embedding';
+
+        $connection->expects($this->once())
+            ->method('executeStatement')
+            ->with($expectedSql, [
+                'id' => $uuid->toRfc4122(),
+                'metadata' => json_encode($metadata),
+                'vector' => '[0.1,0.2,0.3]',
+            ]);
+
+        $store = new Store($connection, 'embeddings');
+        $store->add(new VectorDocument(
+            id: $uuid,
+            vector: new Vector($vectorData),
+            metadata: new Metadata($metadata),
+        ));
+    }
+
+    public function testQueryWithMariaDB(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform = $this->createMock(MariaDBPlatform::class);
+        $result = $this->createMock(Result::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $uuid = Uuid::v4();
+        $vectorData = [0.1, 0.2, 0.3];
+        $minScore = 0.8;
+
+        $expectedSql = <<<'SQL'
+            SELECT id, VEC_ToText(embedding) embedding, metadata, VEC_DISTANCE_EUCLIDEAN(embedding, VEC_FromText(:embedding)) AS score
+            FROM embeddings
+            WHERE VEC_DISTANCE_EUCLIDEAN(embedding, VEC_FromText(:embedding)) >= :minScore
+            ORDER BY score ASC
+            LIMIT 10
+            SQL;
+
+        $connection->expects($this->once())
+            ->method('executeQuery')
+            ->with($expectedSql, [
+                'embedding' => json_encode($vectorData),
+                'minScore' => $minScore,
+            ])
+            ->willReturn($result);
+
+        $result->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'id' => $uuid->toBinary(),
+                    'embedding' => json_encode($vectorData),
+                    'metadata' => json_encode(['title' => 'Test Document']),
+                    'score' => 0.85,
+                ],
+            ]);
+
+        $store = new Store($connection, 'embeddings');
+        $results = $store->query(new Vector($vectorData), ['limit' => 10], $minScore);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(VectorDocument::class, $results[0]);
+        $this->assertSame(0.85, $results[0]->score);
+        $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
+    }
+
+    public function testQueryWithPostgreSQL(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform = $this->createMock(PostgreSQLPlatform::class);
+        $result = $this->createMock(Result::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $uuid = Uuid::v4();
+        $vectorData = [0.1, 0.2, 0.3];
+
+        $expectedSql = 'SELECT id, embedding AS embedding, metadata, (embedding <-> :embedding) AS score
+             FROM embeddings
+             
+             ORDER BY score ASC
+             LIMIT 5';
+
+        $connection->expects($this->once())
+            ->method('executeQuery')
+            ->with($expectedSql, [
+                'embedding' => '[0.1,0.2,0.3]',
+            ])
+            ->willReturn($result);
+
+        $result->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'id' => $uuid->toRfc4122(),
+                    'embedding' => '[0.1,0.2,0.3]',
+                    'metadata' => json_encode(['title' => 'Test Document']),
+                    'score' => 0.95,
+                ],
+            ]);
+
+        $store = new Store($connection, 'embeddings');
+        $results = $store->query(new Vector($vectorData));
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(VectorDocument::class, $results[0]);
+        $this->assertSame(0.95, $results[0]->score);
+    }
+
+    public function testInitializeForMariaDB(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform = $this->createMock(MariaDBPlatform::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $connection->expects($this->once())
+            ->method('getServerVersion')
+            ->willReturn('11.7.0-MariaDB');
+
+        $expectedSql = <<<'SQL'
+            CREATE TABLE IF NOT EXISTS embeddings (
+                id BINARY(16) NOT NULL PRIMARY KEY,
+                metadata JSON,
+                embedding VECTOR(768) NOT NULL,
+                VECTOR INDEX embedding_idx (embedding)
+            )
+            SQL;
+
+        $connection->expects($this->once())
+            ->method('executeStatement')
+            ->with($expectedSql);
+
+        $store = new Store($connection, 'embeddings', 'embedding_idx');
+        $store->initialize(['dimensions' => 768]);
+    }
+
+    public function testInitializeForPostgreSQL(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform = $this->createMock(PostgreSQLPlatform::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $connection->expects($this->exactly(3))
+            ->method('executeStatement')
+            ->willReturnCallback(function ($sql) {
+                static $callCount = 0;
+                $callCount++;
+
+                $expectedSqls = [
+                    'CREATE EXTENSION IF NOT EXISTS vector',
+                    'CREATE TABLE IF NOT EXISTS embeddings (
+                    id UUID PRIMARY KEY,
+                    metadata JSONB,
+                    embedding vector(768) NOT NULL
+                )',
+                    'CREATE INDEX IF NOT EXISTS embeddings_embedding_idx ON embeddings USING ivfflat (embedding vector_cosine_ops)',
+                ];
+
+                $this->assertSame($expectedSqls[$callCount - 1], $sql);
+
+                return 0;
+            });
+
+        $store = new Store($connection, 'embeddings');
+        $store->initialize(['vector_size' => 768]);
+    }
+
+    public function testInitializeWithUnsupportedPlatform(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform = $this->createMock(SQLitePlatform::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $store = new Store($connection, 'embeddings');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported database platform: '.SQLitePlatform::class);
+
+        $store->initialize();
+    }
+}


### PR DESCRIPTION
## Summary
- Implements #85 by providing a DbalStore that automatically detects and adapts to different database platforms
- Addresses #84 by using DBAL Connection instead of PDO, enabling lazy connections
- Supports MariaDB >=11.7 and PostgreSQL with pgvector

## Implementation Details

### DbalStore Features
- Takes a DBAL Connection as dependency (solving the "heavy constructor" issue)
- Automatically detects the database platform using `getDatabasePlatform()`
- Delegates to platform-specific implementations internally
- Maintains the same interface as other vector stores

### Supported Platforms
1. **MariaDB >=11.7**
   - Uses native `VECTOR` type and functions (`VEC_FromText`, `VEC_ToText`)
   - Creates `VECTOR INDEX` for efficient similarity search
   - Uses `VEC_DISTANCE_EUCLIDEAN` for distance calculations

2. **PostgreSQL with pgvector**
   - Uses `vector` type with array syntax
   - Creates ivfflat index with cosine similarity
   - Uses `<->` operator for distance calculations

### Benefits
- Single implementation handles multiple database platforms
- DBAL connections are lazy by default
- Easy to switch between supported databases without code changes
- Extensible design allows adding new platforms easily

## Test plan
- [x] Unit tests for both MariaDB and PostgreSQL platforms
- [x] Tests for unsupported platform handling
- [x] Example script demonstrating usage
- [ ] Integration tests with real databases (would need CI setup)

🤖 Generated with [Claude Code](https://claude.ai/code)