### PR TITLE
[Platform][Albert] Validate URL only in PlatformFactory

### DIFF
--- a/src/platform/src/Bridge/Albert/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Albert/EmbeddingsModelClient.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Platform\Bridge\Albert;
 
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
-use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -29,8 +28,6 @@ final readonly class EmbeddingsModelClient implements ModelClientInterface
         #[\SensitiveParameter] private string $apiKey,
         private string $baseUrl,
     ) {
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
-        '' !== $baseUrl || throw new InvalidArgumentException('The base URL must not be empty.');
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/Albert/GptModelClient.php
+++ b/src/platform/src/Bridge/Albert/GptModelClient.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Platform\Bridge\Albert;
 
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
-use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -33,9 +32,6 @@ final readonly class GptModelClient implements ModelClientInterface
         private string $baseUrl,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
-        '' !== $baseUrl || throw new InvalidArgumentException('The base URL must not be empty.');
     }
 
     public function supports(Model $model): bool

--- a/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
@@ -18,7 +18,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Albert\EmbeddingsModelClient;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
-use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 
@@ -26,30 +25,6 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 #[Small]
 final class EmbeddingsModelClientTest extends TestCase
 {
-    public function testConstructorThrowsExceptionForEmptyApiKey()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The API key must not be empty.');
-
-        new EmbeddingsModelClient(
-            new MockHttpClient(),
-            '',
-            'https://albert.example.com/'
-        );
-    }
-
-    public function testConstructorThrowsExceptionForEmptyBaseUrl()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The base URL must not be empty.');
-
-        new EmbeddingsModelClient(
-            new MockHttpClient(),
-            'test-api-key',
-            ''
-        );
-    }
-
     public function testSupportsEmbeddingsModel()
     {
         $client = new EmbeddingsModelClient(

--- a/src/platform/tests/Bridge/Albert/GptModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/GptModelClientTest.php
@@ -18,7 +18,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Albert\GptModelClient;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
-use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -27,30 +26,6 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 #[Small]
 final class GptModelClientTest extends TestCase
 {
-    public function testConstructorThrowsExceptionForEmptyApiKey()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The API key must not be empty.');
-
-        new GptModelClient(
-            new MockHttpClient(),
-            '',
-            'https://albert.example.com/'
-        );
-    }
-
-    public function testConstructorThrowsExceptionForEmptyBaseUrl()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The base URL must not be empty.');
-
-        new GptModelClient(
-            new MockHttpClient(),
-            'test-api-key',
-            ''
-        );
-    }
-
     public function testConstructorWrapsHttpClientInEventSourceHttpClient()
     {
         self::expectNotToPerformAssertions();


### PR DESCRIPTION
## Summary
- Removes redundant validation from individual model clients (`GptModelClient` and `EmbeddingsModelClient`)
- Keeps URL validation only in `PlatformFactory::create()` as the single entry point
- Updates tests to reflect the validation changes

## Context
This PR implements the approach discussed in #313 - validating URLs directly in the constructor/factory method without creating a separate validator class. The validation is now only performed at the entry point (`PlatformFactory`), following the principle of "validate once at the boundary".

## Changes
- Removed empty string checks from `GptModelClient` and `EmbeddingsModelClient` constructors
- Removed unused `InvalidArgumentException` imports
- Updated test files to remove tests for empty API key/base URL validation in model clients
- All URL validation remains in `PlatformFactory::create()` with proper checks for HTTPS, trailing slash, and API version

## Test Plan
- [x] Run unit tests: `./vendor/bin/phpunit tests/Bridge/Albert/`
- [x] All tests pass (35 tests, 97 assertions)