### PR TITLE
various

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Add support for Albert API for French/EU data sovereignty
  * Add unified abstraction layer for interacting with various AI models and providers
- * Add support for 15+ AI providers:
+ * Add support for 19+ AI providers:
    - OpenAI (GPT-4, GPT-3.5, DALL·E, Whisper)
    - Anthropic (Claude models via native API and AWS Bedrock)
    - Google (VertexAi and Gemini models with server-side tools support)


### PR DESCRIPTION
## Summary
- Corrected AI provider count in changelog from 15+ to 19+

The platform actually supports 19+ AI providers based on the bridge implementations, not 15+ as previously stated.