### PR TITLE
Fix duplicate setFactory call for Ollama platform

### DIFF
--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -4,7 +4,6 @@ ai:
             api_key: '%env(OPENAI_API_KEY)%'
     agent:
         blog:
-            # platform: 'ai.platform.anthropic'
             model:
                 class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
                 name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -406,7 +406,6 @@ final class AiBundle extends AbstractBundle
         if ('ollama' === $type) {
             $platformId = 'ai.platform.ollama';
             $definition = (new Definition(Platform::class))
-                ->setFactory(MistralPlatformFactory::class.'::create')
                 ->setFactory(OllamaPlatformFactory::class.'::create')
                 ->setLazy(true)
                 ->addTag('proxy', ['interface' => PlatformInterface::class])


### PR DESCRIPTION
## Summary
- Remove duplicate `->setFactory(MistralPlatformFactory::class.'::create')` call in Ollama platform configuration
- Fixes configuration error that was using wrong factory for Ollama platform

## Test plan
- [ ] Verify Ollama platform configuration works correctly
- [ ] Check that no other platform configurations are affected
- [ ] Run tests to ensure bundle configuration is valid

🤖 Generated with [Claude Code](https://claude.ai/code)